### PR TITLE
add simple logger

### DIFF
--- a/applog/simple.go
+++ b/applog/simple.go
@@ -1,0 +1,123 @@
+package applog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type simpleLogger struct {
+	mu    sync.Mutex
+	out   io.Writer
+	level Level
+}
+
+// NewSimpleLogger creates a simple logger that outputs only message.
+// It handles the necessity of output according to the log level.
+func NewSimpleLogger(w io.Writer, opts ...Option) (Logger, error) {
+	logger := &simpleLogger{
+		out: w,
+	}
+	for _, opt := range opts {
+		if err := opt(logger); err != nil {
+			return nil, err
+		}
+	}
+	return logger, nil
+}
+
+func (l *simpleLogger) setLevel(lv Level) error {
+	l.level = lv
+	return nil
+}
+
+func (l *simpleLogger) setTimeFormat(format string) error {
+	return errors.New("TimeFormatOption is not available for simpleLogger")
+}
+
+func (l *simpleLogger) setImageTag(tag string) error {
+	return errors.New("ImageTagOption is not available for simpleLogger")
+}
+
+func (l *simpleLogger) Critical(ctx context.Context, msg string) {
+	l.Print(ctx, CriticalLevel, msg, nil)
+}
+
+func (l *simpleLogger) Error(ctx context.Context, msg string) {
+	l.Print(ctx, ErrorLevel, msg, nil)
+}
+
+func (l *simpleLogger) Warn(ctx context.Context, msg string) {
+	l.Print(ctx, WarnLevel, msg, nil)
+}
+
+func (l *simpleLogger) Info(ctx context.Context, msg string) {
+	l.Print(ctx, InfoLevel, msg, nil)
+}
+
+func (l *simpleLogger) Debug(ctx context.Context, msg string) {
+	l.Print(ctx, DebugLevel, msg, nil)
+}
+
+func (l *simpleLogger) Trace(ctx context.Context, msg string) {
+	l.Print(ctx, TraceLevel, msg, nil)
+}
+
+func (l *simpleLogger) Criticalf(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, CriticalLevel, format, a...)
+}
+
+func (l *simpleLogger) Errorf(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, ErrorLevel, format, a...)
+}
+
+func (l *simpleLogger) Warnf(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, WarnLevel, format, a...)
+}
+
+func (l *simpleLogger) Infof(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, InfoLevel, format, a...)
+}
+
+func (l *simpleLogger) Debugf(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, DebugLevel, format, a...)
+}
+
+func (l *simpleLogger) Tracef(ctx context.Context, format string, a ...interface{}) {
+	l.printf(ctx, TraceLevel, format, a...)
+}
+
+func (l *simpleLogger) printf(ctx context.Context, lv Level, format string, a ...interface{}) {
+	l.Print(ctx, lv, fmt.Sprintf(format, a...), nil)
+}
+
+func (l *simpleLogger) Print(ctx context.Context, lv Level, msg string, labels map[string]string) {
+	if !shouldPrint(l.level, lv) {
+		return
+	}
+
+	labelMsg := ""
+	if len(labels) > 0 {
+		keys := make([]string, len(labels))
+		i := 0
+		for key := range labels {
+			keys[i] = key
+			i++
+		}
+		sort.Strings(keys)
+
+		ls := make([]string, len(labels))
+		for i, key := range keys {
+			ls[i] = fmt.Sprintf("%s: %s", key, labels[key])
+		}
+		labelMsg = fmt.Sprintf(" (%s)", strings.Join(ls, ", "))
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintln(l.out, msg+labelMsg)
+}

--- a/applog/simple_test.go
+++ b/applog/simple_test.go
@@ -1,0 +1,151 @@
+package applog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/takuoki/golib/applog"
+)
+
+func TestSimpleLoggerPrint(t *testing.T) {
+	testcase := map[string]struct {
+		settingLevel applog.Level
+		printLevel   applog.Level
+		message      string
+		labels       map[string]string
+		want         string
+	}{
+		"default": {
+			printLevel: applog.InfoLevel,
+			message:    "message",
+			want:       "message\n",
+		},
+		"labels": {
+			printLevel: applog.InfoLevel,
+			message:    "message",
+			labels:     map[string]string{"foo": "abc", "bar": "xyz"},
+			want:       `message \(bar: xyz, foo: abc\)` + "\n",
+		},
+		"break-line": {
+			printLevel: applog.InfoLevel,
+			message:    "message\nmessage",
+			want:       "message\nmessage\n",
+		},
+		"no-output": {
+			settingLevel: applog.ErrorLevel,
+			printLevel:   applog.InfoLevel,
+			message:      "message",
+			want:         "",
+		},
+	}
+
+	for name, c := range testcase {
+		t.Run(name, func(t *testing.T) {
+			opts := []applog.Option{}
+			if c.settingLevel != 0 {
+				opts = append(opts, applog.LevelOption(c.settingLevel))
+			}
+
+			buf := &bytes.Buffer{}
+			logger, err := applog.NewSimpleLogger(buf, opts...)
+			if err != nil {
+				t.Fatalf("error occurred in NewSimpleLogger: %v", err)
+			}
+
+			ctx := context.Background()
+			logger.Print(ctx, c.printLevel, c.message, c.labels)
+
+			assert.Regexp(t, "^"+c.want+"$", buf.String())
+		})
+	}
+}
+
+func TestSimpleLoggerLevel(t *testing.T) {
+	newLogger := func(w io.Writer) applog.Logger {
+		l, err := applog.NewSimpleLogger(w, applog.LevelOption(applog.UnknownLevel))
+		if err != nil {
+			t.Fatalf("error occurred in NewSimpleLogger: %v", err)
+		}
+		return l
+	}
+	t.Run("critical", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Critical(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("error", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Error(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("warn", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Warn(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("info", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Info(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("debug", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Debug(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("trace", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Trace(context.Background(), "message")
+		assert.Regexp(t, "^message\n$", buf.String())
+	})
+	t.Run("criticalf", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Criticalf(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+	t.Run("errorf", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Errorf(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+	t.Run("warnf", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Warnf(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+	t.Run("infof", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Infof(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+	t.Run("debugf", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Debugf(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+	t.Run("tracef", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		newLogger(buf).Tracef(context.Background(), "value: %s", "abc")
+		assert.Regexp(t, "^value: abc\n$", buf.String())
+	})
+}
+
+func TestSimpleLoggerOptionError(t *testing.T) {
+	t.Run("timeFormat", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		_, err := applog.NewSimpleLogger(buf, applog.TimeFormatOption("dummy"))
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "TimeFormatOption is not available for simpleLogger", err.Error())
+		}
+	})
+	t.Run("imageTag", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		_, err := applog.NewSimpleLogger(buf, applog.ImageTagOption("dummy"))
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "ImageTagOption is not available for simpleLogger", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
指定された文字列をそのまま出力するだけのロガー。
主な利用用途は、テストコード内のログ出力内容のチェック。